### PR TITLE
Implement symmetric ICP

### DIFF
--- a/cpp/open3d/pipelines/CMakeLists.txt
+++ b/cpp/open3d/pipelines/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(pipelines PRIVATE
     registration/FastGlobalRegistration.cpp
     registration/Feature.cpp
     registration/GeneralizedICP.cpp
+    registration/SymmetricICP.cpp
     registration/GlobalOptimization.cpp
     registration/PoseGraph.cpp
     registration/Registration.cpp

--- a/cpp/open3d/pipelines/registration/SymmetricICP.cpp
+++ b/cpp/open3d/pipelines/registration/SymmetricICP.cpp
@@ -1,0 +1,126 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include "open3d/pipelines/registration/SymmetricICP.h"
+
+#include <Eigen/Geometry>
+
+#include "open3d/geometry/PointCloud.h"
+#include "open3d/utility/Eigen.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace pipelines {
+namespace registration {
+
+double TransformationEstimationSymmetric::ComputeRMSE(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        const CorrespondenceSet &corres) const {
+    if (corres.empty() || !target.HasNormals() || !source.HasNormals()) {
+        return 0.0;
+    }
+    double err = 0.0;
+    for (const auto &c : corres) {
+        const Eigen::Vector3d &vs = source.points_[c[0]];
+        const Eigen::Vector3d &vt = target.points_[c[1]];
+        const Eigen::Vector3d &ns = source.normals_[c[0]];
+        const Eigen::Vector3d &nt = target.normals_[c[1]];
+        Eigen::Vector3d d = vs - vt;
+        double r1 = d.dot(nt);
+        double r2 = d.dot(ns);
+        err += r1 * r1 + r2 * r2;
+    }
+    return std::sqrt(err / (double)corres.size());
+}
+
+Eigen::Matrix4d TransformationEstimationSymmetric::ComputeTransformation(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        const CorrespondenceSet &corres) const {
+    if (corres.empty() || !target.HasNormals() || !source.HasNormals()) {
+        return Eigen::Matrix4d::Identity();
+    }
+
+    auto compute_jacobian_and_residual =
+            [&](int i,
+                std::vector<Eigen::Vector6d, utility::Vector6d_allocator> &J_r,
+                std::vector<double> &r, std::vector<double> &w) {
+                const Eigen::Vector3d &vs = source.points_[corres[i][0]];
+                const Eigen::Vector3d &vt = target.points_[corres[i][1]];
+                const Eigen::Vector3d &ns = source.normals_[corres[i][0]];
+                const Eigen::Vector3d &nt = target.normals_[corres[i][1]];
+                Eigen::Vector3d d = vs - vt;
+
+                J_r.resize(2);
+                r.resize(2);
+                w.resize(2);
+
+                r[0] = d.dot(nt);
+                w[0] = kernel_->Weight(r[0]);
+                J_r[0].block<3, 1>(0, 0) = vs.cross(nt);
+                J_r[0].block<3, 1>(3, 0) = nt;
+
+                r[1] = d.dot(ns);
+                w[1] = kernel_->Weight(r[1]);
+                J_r[1].block<3, 1>(0, 0) = vs.cross(ns);
+                J_r[1].block<3, 1>(3, 0) = ns;
+            };
+
+    Eigen::Matrix6d JTJ;
+    Eigen::Vector6d JTr;
+    double r2;
+    std::tie(JTJ, JTr, r2) =
+            utility::ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
+                    compute_jacobian_and_residual, (int)corres.size());
+
+    bool is_success;
+    Eigen::Matrix4d extrinsic;
+    std::tie(is_success, extrinsic) =
+            utility::SolveJacobianSystemAndObtainExtrinsicMatrix(JTJ, JTr);
+
+    return is_success ? extrinsic : Eigen::Matrix4d::Identity();
+}
+
+std::tuple<std::shared_ptr<const geometry::PointCloud>,
+           std::shared_ptr<const geometry::PointCloud>>
+TransformationEstimationSymmetric::
+        InitializePointCloudsForTransformation(
+                const geometry::PointCloud &source,
+                const geometry::PointCloud &target,
+                double max_correspondence_distance) const {
+    if (!target.HasNormals() || !source.HasNormals()) {
+        utility::LogError(
+                "SymmetricICP requires both source and target to have normals.");
+    }
+    std::shared_ptr<const geometry::PointCloud> source_initialized_c(
+            &source, [](const geometry::PointCloud *) {});
+    std::shared_ptr<const geometry::PointCloud> target_initialized_c(
+            &target, [](const geometry::PointCloud *) {});
+    if (!source_initialized_c || !target_initialized_c) {
+        utility::LogError(
+                "Internal error: InitializePointCloudsForTransformation returns "
+                "nullptr.");
+    }
+    return std::make_tuple(source_initialized_c, target_initialized_c);
+}
+
+RegistrationResult RegistrationSymmetricICP(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        double max_correspondence_distance,
+        const Eigen::Matrix4d &init,
+        const TransformationEstimationSymmetric &estimation,
+        const ICPConvergenceCriteria &criteria) {
+    return RegistrationICP(source, target, max_correspondence_distance, init,
+                           estimation, criteria);
+}
+
+}  // namespace registration
+}  // namespace pipelines
+}  // namespace open3d
+

--- a/cpp/open3d/pipelines/registration/SymmetricICP.h
+++ b/cpp/open3d/pipelines/registration/SymmetricICP.h
@@ -1,0 +1,68 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <Eigen/Core>
+#include <memory>
+
+#include "open3d/pipelines/registration/Registration.h"
+#include "open3d/pipelines/registration/RobustKernel.h"
+#include "open3d/pipelines/registration/TransformationEstimation.h"
+
+namespace open3d {
+namespace pipelines {
+namespace registration {
+
+class RegistrationResult;
+
+/// \brief Transformation estimation for symmetric ICP using point-to-plane
+/// errors from both source and target.
+class TransformationEstimationSymmetric : public TransformationEstimation {
+public:
+    explicit TransformationEstimationSymmetric(
+            std::shared_ptr<RobustKernel> kernel =
+                    std::make_shared<L2Loss>())
+        : kernel_(std::move(kernel)) {}
+    ~TransformationEstimationSymmetric() override {}
+
+    TransformationEstimationType GetTransformationEstimationType() const override {
+        return TransformationEstimationType::PointToPlane;
+    }
+    double ComputeRMSE(const geometry::PointCloud &source,
+                       const geometry::PointCloud &target,
+                       const CorrespondenceSet &corres) const override;
+    Eigen::Matrix4d ComputeTransformation(
+            const geometry::PointCloud &source,
+            const geometry::PointCloud &target,
+            const CorrespondenceSet &corres) const override;
+
+    std::tuple<std::shared_ptr<const geometry::PointCloud>,
+               std::shared_ptr<const geometry::PointCloud>>
+    InitializePointCloudsForTransformation(
+            const geometry::PointCloud &source,
+            const geometry::PointCloud &target,
+            double max_correspondence_distance) const override;
+
+public:
+    std::shared_ptr<RobustKernel> kernel_;
+};
+
+/// \brief Function for symmetric ICP registration using point-to-plane error.
+RegistrationResult RegistrationSymmetricICP(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        double max_correspondence_distance,
+        const Eigen::Matrix4d &init = Eigen::Matrix4d::Identity(),
+        const TransformationEstimationSymmetric &estimation =
+                TransformationEstimationSymmetric(),
+        const ICPConvergenceCriteria &criteria = ICPConvergenceCriteria());
+
+}  // namespace registration
+}  // namespace pipelines
+}  // namespace open3d
+

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -16,6 +16,7 @@
 #include "open3d/pipelines/registration/FastGlobalRegistration.h"
 #include "open3d/pipelines/registration/Feature.h"
 #include "open3d/pipelines/registration/GeneralizedICP.h"
+#include "open3d/pipelines/registration/SymmetricICP.h"
 #include "open3d/pipelines/registration/RobustKernel.h"
 #include "open3d/pipelines/registration/TransformationEstimation.h"
 #include "open3d/utility/Logging.h"
@@ -105,6 +106,12 @@ void pybind_registration_declarations(py::module &m) {
             te_p2l(m_registration, "TransformationEstimationPointToPlane",
                    "Class to estimate a transformation for point to plane "
                    "distance.");
+    py::class_<TransformationEstimationSymmetric,
+               PyTransformationEstimation<TransformationEstimationSymmetric>,
+               TransformationEstimation>
+            te_sym(m_registration, "TransformationEstimationSymmetric",
+                    "Class to estimate a transformation for symmetric "
+                    "point to plane distance.");
     py::class_<
             TransformationEstimationForColoredICP,
             PyTransformationEstimation<TransformationEstimationForColoredICP>,
@@ -306,6 +313,28 @@ Sets :math:`c = 1` if ``with_scaling`` is ``False``.
             .def_readwrite("kernel",
                            &TransformationEstimationPointToPlane::kernel_,
                            "Robust Kernel used in the Optimization");
+
+    auto te_sym = static_cast<py::class_<
+            TransformationEstimationSymmetric,
+            PyTransformationEstimation<TransformationEstimationSymmetric>,
+            TransformationEstimation>>(m_registration.attr(
+            "TransformationEstimationSymmetric"));
+    py::detail::bind_default_constructor<TransformationEstimationSymmetric>(
+            te_sym);
+    py::detail::bind_copy_functions<TransformationEstimationSymmetric>(te_sym);
+    te_sym.def(py::init([](std::shared_ptr<RobustKernel> kernel) {
+                   return new TransformationEstimationSymmetric(
+                           std::move(kernel));
+               }),
+               "kernel"_a)
+           .def("__repr__",
+                 [](const TransformationEstimationSymmetric &te) {
+                     return std::string("TransformationEstimationSymmetric");
+                 })
+            .def_readwrite(
+                    "kernel",
+                    &TransformationEstimationSymmetric::kernel_,
+                    "Robust Kernel used in the Optimization");
 
     // open3d.registration.TransformationEstimationForColoredICP :
     auto te_col = static_cast<py::class_<
@@ -625,10 +654,11 @@ must hold true for all edges.)");
                     {"criteria", "Convergence criteria"},
                     {"estimation_method",
                      "Estimation method. One of "
-                     "(``TransformationEstimationPointToPoint``, "
-                     "``TransformationEstimationPointToPlane``, "
-                     "``TransformationEstimationForGeneralizedICP``, "
-                     "``TransformationEstimationForColoredICP``)"},
+                    "(``TransformationEstimationPointToPoint``, "
+                    "``TransformationEstimationPointToPlane``, "
+                    "``TransformationEstimationSymmetric``, "
+                    "``TransformationEstimationForGeneralizedICP``, "
+                    "``TransformationEstimationForColoredICP``)"},
                     {"init", "Initial transformation estimation"},
                     {"lambda_geometric", "lambda_geometric value"},
                     {"epsilon", "epsilon value"},
@@ -667,6 +697,17 @@ must hold true for all edges.)");
             "estimation_method"_a = TransformationEstimationPointToPoint(false),
             "criteria"_a = ICPConvergenceCriteria());
     docstring::FunctionDocInject(m_registration, "registration_icp",
+                                 map_shared_argument_docstrings);
+
+    m_registration.def(
+            "registration_symmetric_icp", &RegistrationSymmetricICP,
+            py::call_guard<py::gil_scoped_release>(),
+            "Function for symmetric ICP registration", "source"_a, "target"_a,
+            "max_correspondence_distance"_a,
+            "init"_a = Eigen::Matrix4d::Identity(),
+            "estimation_method"_a = TransformationEstimationSymmetric(),
+            "criteria"_a = ICPConvergenceCriteria());
+    docstring::FunctionDocInject(m_registration, "registration_symmetric_icp",
                                  map_shared_argument_docstrings);
 
     m_registration.def("registration_colored_icp", &RegistrationColoredICP,


### PR DESCRIPTION
## Summary
- add symmetric point-to-plane ICP implementation
- expose the feature in Python bindings
- rename estimator to `TransformationEstimationSymmetric`
- add unit test covering symmetric ICP

## Testing
- `python util/check_style.py --apply` *(fails: ModuleNotFoundError: No module named 'yapf')*
- `python -m pytest python/test/t/registration/test_registration.py::test_icp_symmetric -q` *(fails: found no collectors)*